### PR TITLE
Remove deprecated argument

### DIFF
--- a/dojo.rb
+++ b/dojo.rb
@@ -2,7 +2,6 @@ class Dojo < Formula
   desc "Containerize your development and operations environment"
   homepage "https://github.com/kudulab/dojo"
   version "0.10.3"
-  bottle :unneeded
 
 if OS.mac?
     url "https://github.com/kudulab/dojo/releases/download/0.10.3/dojo_darwin_amd64"


### PR DESCRIPTION
Causing the following warning:
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the kudulab/dojo-osx tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/kudulab/homebrew-dojo-osx/dojo.rb:5
```